### PR TITLE
Exploit fix

### DIFF
--- a/src/main/java/dev/therealdan/grandexchange/core/GrandExchange.java
+++ b/src/main/java/dev/therealdan/grandexchange/core/GrandExchange.java
@@ -85,8 +85,8 @@ public class GrandExchange {
             if (itemStack == null || itemStack.getType().equals(Material.AIR)) continue;
             int amount = itemStack.getAmount();
             while (amount > 0) {
-                value += simulation.getBaseSellPrice(itemStack.getType());
                 simulation.addStock(itemStack.getType(), 1);
+                value += simulation.getBaseSellPrice(itemStack.getType());
                 amount--;
             }
         }


### PR DESCRIPTION
The endpoints of stock were mismatched before allowing in specific cases to buy and sell the same item and quantity and gain money. Basically, free money exploit