### PR TITLE
Exploit fix

### DIFF
--- a/src/main/java/dev/therealdan/grandexchange/core/GrandExchange.java
+++ b/src/main/java/dev/therealdan/grandexchange/core/GrandExchange.java
@@ -97,8 +97,8 @@ public class GrandExchange {
         GrandExchange simulation = getSimulation();
         long value = 0;
         for (int i = 0; i < stackSize; i++) {
-            value += simulation.getFinalBuyPrice(material);
             simulation.removeStock(material, 1);
+            value += simulation.getFinalBuyPrice(material);
         }
         return value;
     }


### PR DESCRIPTION
The endpoints of stock were not aligned, allowing in specific cases to buy and sell the same item and quantity and gain money. A "free money" exploit if you will